### PR TITLE
Pass along the Universe to a Processor

### DIFF
--- a/src/baldrick/Phase.hx
+++ b/src/baldrick/Phase.hx
@@ -73,6 +73,7 @@ class Phase {
       @return Phase
     */
     public function addProcessor(processor:Processor):Phase {
+        processor.universe = universe;
         processors.push(processor);
         for(entity in universe.entities) {
             processor.match(entity);

--- a/src/baldrick/Processor.hx
+++ b/src/baldrick/Processor.hx
@@ -41,6 +41,12 @@ interface Processor {
     */
     public function process():Void;
 
+    /**
+      The Universe in which the Processor exists. Assigned when
+      the Processor is added to a Phase.
+    */
+    private var universe:baldrick.Universe;
+
     #if profiling
     /**
       The fully-qualified name of the processor to be used when profiling

--- a/src/baldrick/macros/ProcessorMacros.hx
+++ b/src/baldrick/macros/ProcessorMacros.hx
@@ -47,6 +47,7 @@ class ProcessorMacros {
         var hasMatchField:Bool = false;
         var hasUnmatch:Bool = false;
         var hasConstructor:Bool = false;
+        var hasUniverse:Bool = false;
         for(field in fields) {
             if(field.name == 'match') {
                 hasMatchField = true;
@@ -56,6 +57,9 @@ class ProcessorMacros {
             }
             else if(field.name == 'new') {
                 hasConstructor = true;
+            }
+            else if(field.name == 'universe') {
+                hasUniverse = true;
             }
         }
 
@@ -69,6 +73,10 @@ class ProcessorMacros {
 
         if(!hasConstructor) {
             fields = injectConstructor(fields);
+        }
+
+        if(!hasUniverse) {
+            fields = injectUniverse(fields);
         }
 
         var typeID:Int = getTypeID(Context.getLocalClass().get().name);
@@ -311,6 +319,16 @@ class ProcessorMacros {
             })
         });
 
+        return fields;
+    }
+
+    private static function injectUniverse(fields:Array<Field>):Array<Field> {
+        fields.push({
+            name:  "universe",
+            access:  [Access.APrivate],
+            kind: FieldType.FVar(macro:baldrick.Universe, macro $v{null}),
+            pos: Context.currentPos(),
+        });
         return fields;
     }
 


### PR DESCRIPTION
This PR just connects a few existing dots to allow the Universe to be accessible to a Processor.

I wanted this functionality when I started, but I'm no longer totally convinced this is the correct approach. It _does_ work, but with a few caveats:

1. Universe won't get assigned until the Processor is added to a Phase (just something to keep in mind)
2. It assumes that a Processor will only ever be in a single Universe. Which makes sense, but I don't think there are any technical reasons you couldn't have multiple-Universes sharing a Processor. If you find a practical reason why you'd want to do that, I'd love to hear your use-case 😁.

I also never had issues with what the `#display` stuff fixes, so this PR might not be complete because I didn't want to blindly copy that without verifying it did what it's supposed to.

And thanks! I've been having a blast working with this framework lately.